### PR TITLE
Update `globals` dependency, raise typescript target to `es2022`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint": ">=8.40.0"
   },
   "dependencies": {
-    "globals": "^13.23.0"
+    "globals": "^16.4.0"
   },
   "devDependencies": {
     "@anolilab/semantic-release-clean-package-json": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "examples"
   ],
   "engines": {
-    "node": ">=16.6.0"
+    "node": ">=16.9.0"
   },
   "type": "module",
   "types": "./index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       globals:
-        specifier: ^13.23.0
-        version: 13.23.0
+        specifier: ^16.4.0
+        version: 16.4.0
     devDependencies:
       '@anolilab/semantic-release-clean-package-json':
         specifier: ^3.0.2
@@ -3027,6 +3027,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: true
 
   /globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3036,6 +3037,11 @@ packages:
     resolution: {integrity: sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==}
     engines: {node: '>=18'}
     dev: true
+
+  /globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+    engines: {node: '>=18'}
+    dev: false
 
   /globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -5337,6 +5343,7 @@ packages:
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+    dev: true
 
   /type-fest@1.4.0:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
@@ -5798,5 +5805,5 @@ packages:
       eslint: '>=8.40.0'
     dependencies:
       eslint: 9.13.0
-      globals: 13.23.0
+      globals: 16.4.0
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5800,7 +5800,7 @@ packages:
     resolution: {directory: '', type: directory}
     id: 'file:'
     name: eslint-plugin-playwright
-    engines: {node: '>=16.6.0'}
+    engines: {node: '>=16.9.0'}
     peerDependencies:
       eslint: '>=8.40.0'
     dependencies:

--- a/src/rules/prefer-web-first-assertions.ts
+++ b/src/rules/prefer-web-first-assertions.ts
@@ -85,7 +85,7 @@ export default createRule({
         // Playwright method must be supported
         const method = getStringValue(call.callee.property)
         const methodConfig = methods[method]
-        if (!Object.hasOwn(methods, method)) return
+        if (!Object.prototype.hasOwnProperty.call(methods, method)) return
 
         // Change the matcher
         const notModifier = fnCall.modifiers.find(

--- a/src/rules/prefer-web-first-assertions.ts
+++ b/src/rules/prefer-web-first-assertions.ts
@@ -85,7 +85,7 @@ export default createRule({
         // Playwright method must be supported
         const method = getStringValue(call.callee.property)
         const methodConfig = methods[method]
-        if (!Object.prototype.hasOwnProperty.call(methods, method)) return
+        if (!Object.hasOwn(methods, method)) return
 
         // Change the matcher
         const notModifier = fnCall.modifiers.find(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "strict": true,


### PR DESCRIPTION
Relevant release notes:

- https://github.com/sindresorhus/globals/releases/tag/v14.0.0
- https://github.com/sindresorhus/globals/releases/tag/v15.0.0
- https://github.com/sindresorhus/globals/releases/tag/v16.0.0

Notably, this removes the dependency `type-fest` from this plugin.