### PR TITLE
fix: Rename default export `playwright`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-import plugin from './dist/index.cjs'
+import playwright from './dist/index.cjs'
 
-export default plugin
+export default playwright


### PR DESCRIPTION
When importing the default export, it's recommended to use the same name as the exported variable (cf. [_import-x/no-rename-default_](https://github.com/un-ts/eslint-plugin-import-x/blob/v4.17.1/docs/rules/no-rename-default.md)).

This package exports a variable named [`plugin`](https://github.com/mskelton/eslint-plugin-playwright/blob/v2.11.0/index.js#L3). With the following file:

```javascript
import { defineConfig } from '@eslint/config'
import playwright from 'eslint-plugin-playwright'

export default defineConfig([
  {
    files: ['tests/**'],
    extends: [playwright.configs['flat/recommended']],
    rules: {
      // Customize Playwright rules
      // ...
    },
  },
])
```

ESLint and _import-x/no-rename-default_ report this error:

> Caution: `index.js` has a default export `plugin`. This imports `plugin` as `playwright`. Check if you meant to write `import plugin from 'eslint-plugin-playwright'` instead.

---

With this pull request, we will be able to use the name `playwright`.