### PR TITLE
fix(no-raw-locators): flag interpolated template literal locators

### DIFF
--- a/docs/rules/no-raw-locators.md
+++ b/docs/rules/no-raw-locators.md
@@ -45,6 +45,10 @@ An array of raw locators that are allowed. This helps for locators such as
 
 By default, no raw locators are allowed (the equivalent of `{ "ignore": [] }`).
 
+A template literal that contains an interpolation is always reported, since only
+part of its value is known statically and it cannot be compared against this
+option.
+
 Example of **incorrect** code for the `{ "allowed": ["[aria-busy=false]"] }`
 option:
 

--- a/src/rules/no-raw-locators.test.ts
+++ b/src/rules/no-raw-locators.test.ts
@@ -76,6 +76,39 @@ runRuleTester('no-raw-locators', rule, {
       code: test('let button = page.locator(); page.locator(button)'),
       errors: [{ column: 41, endColumn: 55, line: 1, messageId }],
     },
+    // Template literals
+    {
+      code: test('await page.locator(`.btn`)'),
+      errors: [{ column: 34, endColumn: 54, line: 1, messageId }],
+    },
+    {
+      code: test('page.locator(`#row-${id}`)'),
+      errors: [{ column: 28, endColumn: 54, line: 1, messageId }],
+    },
+    {
+      code: test('await page.locator(`[data-testid=${id}]`)'),
+      errors: [{ column: 34, endColumn: 69, line: 1, messageId }],
+    },
+    {
+      code: test('table.locator(`.row-${id}`)'),
+      errors: [{ column: 28, endColumn: 55, line: 1, messageId }],
+    },
+    {
+      code: test('await page.getByRole("region").locator(`#row-${id}`)'),
+      errors: [{ column: 34, endColumn: 80, line: 1, messageId }],
+    },
+    // An interpolated template literal is only partially known, so the
+    // `allowed` option cannot match it
+    {
+      code: test('await page.locator(`iframe${id}`)'),
+      errors: [{ column: 34, endColumn: 61, line: 1, messageId }],
+      options: [{ allowed: ['iframe'] }],
+    },
+    {
+      code: test('await page.locator(`[aria-busy=${value}]`)'),
+      errors: [{ column: 34, endColumn: 70, line: 1, messageId }],
+      options: [{ allowed: ['[aria-busy=false]'] }],
+    },
     // Allowed
     {
       code: test('await page.locator("[aria-busy=false]")'),
@@ -129,6 +162,16 @@ runRuleTester('no-raw-locators', rule, {
 
     // bare calls
     test('() => page.locator'),
+
+    // Template literals without interpolation still honor the `allowed` option
+    {
+      code: test('await page.locator(`iframe`)'),
+      options: [{ allowed: ['iframe'] }],
+    },
+    {
+      code: test('await page.locator(`[aria-busy=false]`)'),
+      options: [{ allowed: ['[aria-busy=false]'] }],
+    },
 
     // Allowed
     {

--- a/src/rules/no-raw-locators.ts
+++ b/src/rules/no-raw-locators.ts
@@ -27,10 +27,17 @@ export default createRule({
           return
         }
 
-        if (
-          (node.arguments.length === 0 || isStringNode(node.arguments[0])) &&
-          !isAllowed(getStringValue(node.arguments[0]))
-        ) {
+        const arg = node.arguments[0]
+
+        // A template literal with interpolation is still a raw locator. Only
+        // part of its value is known statically, so it can never be matched
+        // against the `allowed` option and is always reported.
+        if (arg?.type === 'TemplateLiteral' && arg.quasis.length > 1) {
+          context.report({ messageId: 'noRawLocator', node })
+          return
+        }
+
+        if ((node.arguments.length === 0 || isStringNode(arg)) && !isAllowed(getStringValue(arg))) {
           context.report({ messageId: 'noRawLocator', node })
           return
         }


### PR DESCRIPTION
no-raw-locators` stopped reporting `.locator()` calls whose argument is a
template literal containing an interpolation. Reported in #479, where 2.2.2
flags the call and 2.10.5 stays silent.

```ts
const id = '123'
page.locator(`#row-${id}`) // no report
```

A plain string is still reported, and so is a template literal with nothing
interpolated in it, which makes the gap easy to miss when scanning a codebase
for hits.

## Cause

Since 0e48186 the rule gates on `isStringNode`. That helper accepts a template
literal only when `quasis.length === 1`. It is the right check for callers that
need the whole value at lint time, but not for deciding whether an argument is a
raw locator. A template literal with an interpolation has two or more quasis, so
the call falls through and nothing is reported.

## Change

A template literal argument is now treated as a raw locator whether or not it
interpolates. `isStringNode` stays in place on the path that compares the
argument against the `allowed` option, which can only work on a value that is
fully known at lint time.

An interpolated template literal is therefore always reported and is never
matched against `allowed`, because only the leading static part of it is visible
to the rule. Matching `` `#row-${id}` `` against an allowed entry would come down
to comparing the entry with `#row-`, which is not something a user could
reasonably rely on. The rule doc now says this.

## Tests

`src/rules/no-raw-locators.test.ts` gains invalid cases for the snippet from the
report, for interpolated selectors reached through a nested locator and through
a chained one, and for an interpolated argument under an `allowed` option whose
entry would match the static prefix. Two valid cases cover a template literal
with no interpolation still honoring `allowed`.

The full suite and `yarn ci` are green.

Fixes #479