### PR TITLE
fix(prefer-native-locators): stop the autofix from emitting invalid code

### DIFF
--- a/docs/rules/prefer-native-locators.md
+++ b/docs/rules/prefer-native-locators.md
@@ -33,6 +33,15 @@ page.getByTestId('password-input')
 page.getByTitle('Additional context')
 ```
 
+Only a selector that is exactly one attribute selector is reported. A selector
+that also carries a descendant, a combinator or a second attribute is left
+alone, because no single native locator matches the same set of elements:
+
+```javascript
+page.locator('[data-testid="row"] [role="button"]')
+page.locator('[role="dialog"][data-state="open"]')
+```
+
 ## Options
 
 ```json

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -164,6 +164,27 @@ runRuleTester('prefer-native-locators', rule, {
       errors: [{ column: 1, line: 1, messageId: 'unexpectedTestIdQuery' }],
       output: 'page.locator(".container").getByTestId("input")',
     },
+    // The emitted literal is quoted so that the value survives intact
+    {
+      code: `page.locator('[aria-label="Say \\\\"hi\\\\""]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedLabelQuery' }],
+      output: `page.getByLabel('Say "hi"')`,
+    },
+    {
+      code: `page.locator("[aria-label='Say \\"hi\\"']")`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedLabelQuery' }],
+      output: `page.getByLabel('Say "hi"')`,
+    },
+    {
+      code: `page.locator('[title="it\\'s here"]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedTitleQuery' }],
+      output: `page.getByTitle("it's here")`,
+    },
+    {
+      code: `page.locator("[title='it\\\\'s \\"here\\"']")`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedTitleQuery' }],
+      output: `page.getByTitle("it's \\"here\\"")`,
+    },
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },
@@ -203,6 +224,30 @@ runRuleTester('prefer-native-locators', rule, {
     },
     {
       code: `this.page.locator('[complex-query] > [title="Additional context"]')`,
+    },
+    // A selector that carries more than the one attribute has no equivalent
+    // native locator, so it is left alone
+    {
+      code: `page.locator('[data-testid="a"] [data-testid="b"]')`,
+    },
+    {
+      code: `page.locator('[data-testid="a"] > [data-testid="b"]')`,
+    },
+    {
+      code: `page.locator('[role="dialog"][data-state="open"]')`,
+    },
+    {
+      code: `page.locator('[placeholder="Search"][disabled]')`,
+    },
+    {
+      code: `page.locator('[role="button"], [role="link"]')`,
+    },
+    {
+      code: `page.locator('[aria-label="Close"] span')`,
+    },
+    // Unbalanced quoting is not a selector this rule can rewrite
+    {
+      code: `page.locator('[aria-label="Say "hi""]')`,
     },
     // Works for empty string and no arguments
     { code: `page.locator('')` },

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -43,8 +43,49 @@ const compilePatterns = ({ testIdAttribute }: { testIdAttribute: string }): Patt
   ]
   return patterns.map(({ attribute, ...pattern }) => ({
     ...pattern,
-    pattern: new RegExp(`^\\[${attribute}=['"]?(.+?)['"]?\\]$`),
+    pattern: buildPattern(attribute),
   }))
+}
+
+/**
+ * Matches a selector that is exactly one attribute selector for the given
+ * attribute and nothing else. The value is either quoted, in which case the
+ * only escapes it may contain are for a quote or a backslash, or unquoted, in
+ * which case it may not contain whitespace, quotes, brackets or backslashes.
+ *
+ * Anchoring both ends means a selector that carries a descendant, a sibling
+ * combinator or a second attribute does not match, since no single native
+ * locator is equivalent to it.
+ */
+function buildPattern(attribute: string) {
+  const doubleQuoted = `"((?:[^"\\\\]|\\\\["'\\\\])*)"`
+  const singleQuoted = `'((?:[^'\\\\]|\\\\["'\\\\])*)'`
+  const unquoted = `([^'"\\[\\]\\\\\\s]+)`
+  return new RegExp(
+    `^\\[${escapeRegExp(attribute)}=(?:${doubleQuoted}|${singleQuoted}|${unquoted})\\]$`,
+  )
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** Resolves the escapes a quoted CSS attribute value is allowed to contain. */
+function unescapeValue(value: string) {
+  return value.replace(/\\(["'\\])/g, '$1')
+}
+
+/**
+ * Renders a value as a JavaScript string literal. Double quotes are used by
+ * default to match the rest of the emitted fixes, and single quotes are used
+ * when that keeps the literal free of escapes.
+ */
+function toStringLiteral(value: string) {
+  const doubleQuoted = JSON.stringify(value)
+  if (!value.includes('"') || value.includes("'")) {
+    return doubleQuoted
+  }
+  return `'${doubleQuoted.slice(1, -1).replaceAll('\\"', '"')}'`
 }
 
 export default createRule({
@@ -69,6 +110,8 @@ export default createRule({
         for (const pattern of patterns) {
           const match = query.match(pattern.pattern)
           if (match) {
+            const value = unescapeValue(match[1] ?? match[2] ?? match[3])
+
             context.report({
               fix(fixer) {
                 const start =
@@ -78,7 +121,7 @@ export default createRule({
                 const end = node.range![1]
                 const rangeToReplace: AST.Range = [start, end]
 
-                const newText = `${pattern.replacement}("${match[1]}")`
+                const newText = `${pattern.replacement}(${toStringLiteral(value)})`
                 return fixer.replaceTextRange(rangeToReplace, newText)
               },
               messageId: pattern.messageId,


### PR DESCRIPTION
Running `eslint --fix` with this rule enabled can leave source files that no
longer parse. On a compound selector the fixer writes the rest of the selector
into the middle of the string literal it emits, so the file is corrupted rather
than fixed. In a pre-commit hook or a CI autofix step that lands silently. The
reporter in #482 had four files broken by one run.

Two selector shapes trigger it.

A selector that starts with a matched attribute and then continues:

```ts
page.locator('[data-testid="a"] [data-testid="b"]')
page.locator('[role="dialog"][data-state="open"]')
```

becomes

```ts
page.getByTestId("a"] [data-testid="b")
page.getByRole("dialog"][data-state="open")
```

A value that contains a double quote, since the emitted literal is always double
quoted and the value is never escaped:

```ts
page.locator("[aria-label='Say \"hi\"']")
```

becomes

```ts
page.getByLabel("Say "hi"")
```

Both reproduce on `main`.

`compilePatterns` builds `^\[<attr>=['"]?(.+?)['"]?\]$` for each attribute. The
capture group is lazy, but the pattern is anchored at the end of the string, so
on a compound selector the group has to expand past the closing bracket of the
first attribute and swallow everything up to the last one. That captured text is
then interpolated into `"${match[1]}"` with no escaping applied.

A selector is now matched only when it is exactly one attribute selector for the
attribute in question, with the value either quoted (escapes permitted for a
quote or a backslash) or a bare run with no whitespace, quotes, brackets or
backslashes.

A selector that also carries a descendant or a second attribute no longer matches,
so nothing is reported and no fix is offered. That lines up with how the rule
already treats a selector with a leading class or tag, and it is right because no
single native locator selects the same elements — both `getByTestId('a')` and
`getByRole('dialog')` would have quietly dropped a constraint even if the syntax
had come out right.

The captured value is unescaped and rendered with a quote style picked from its
contents; double quotes remain the default so existing output is unchanged. The
attribute name is also escaped before it goes into the regex, since
`testIdAttribute` comes from user config.

`src/rules/prefer-native-locators.test.ts` gains valid cases for the compound
shapes from the report, covering the ones whose autofix output previously did not
parse, plus invalid cases for a value containing a double quote and for a value
containing both quote characters. Nine of the added cases fail against the
current rule and pass with this change. Every existing case still passes
untouched, and `yarn ci` is green.

Fixes #482